### PR TITLE
Try to make it work better out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,14 @@ you:
 - Merge ([post-merge])
 - Rebase ([post-rewrite])
 
-These git hooks will execute the main [ctags generator] script.
+If the hooks are enabled in the current git config:
+
+	# local to a repo
+	git config hooks.ctags.enable true
+	# global config
+	git config --global hooks.ctags.enable true
+
+Then, they will execute the main [ctags generator] script.
 
 ### Ensure ~/.ctags Configuration
 To set different ctags options, create yourself a `~/.ctags`, I've included an

--- a/contrib/hooks/ctags
+++ b/contrib/hooks/ctags
@@ -30,11 +30,11 @@ if [ "${#cwd}" -lt 150 ]; then
 	hash=${hash//\:/=-}
 elif hash sha256sum 2>/dev/null; then
 	# Use SHA256 for long paths
-	hash=$(printf $cwd | sha256sum | sed 's/\s\+\-.*$//g')
+	hash=$(printf "%s" "$cwd" | sha256sum | sed 's/\s\+\-.*$//g')
 else
 	# Simple hash when sha256sum isn't available
 	sum=0
-	for i in `seq 0 ${#cwd}`; do
+	for i in $(seq 0 ${#cwd}); do
 		char=${cwd:${i}:1}
 		dec=$(printf '%d\n' "'$char")
 		((sum+=dec*(i+1)))
@@ -48,7 +48,9 @@ if [ -z "$hash" ]; then
 fi
 
 # Generate the tags file into the central repository
-filepath="${XDG_CACHE_HOME:-$HOME/.cache}/vim/tags/${hash}"
+cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/vim/tags"
+mkdir -p "${cache_dir}"
+filepath="${cache_dir}/${hash}"
 trap 'rm -f "${filepath}.$$"' EXIT
 
 # Run ctags, store exit code.

--- a/contrib/hooks/plugin-ctags.sh
+++ b/contrib/hooks/plugin-ctags.sh
@@ -6,8 +6,8 @@
 # Runs ctags if enabled in git config
 main()
 {
-	if test $(git config --bool hooks.ctags.enabled) = true; then
-		"$GIT_DIR"/hooks/ctags &
+	if [ "$(git config --bool hooks.ctags.enabled)" = true ]; then
+		"$GIT_DIR/hooks/ctags" &
 	fi
 }
 main

--- a/plugin/tagabana.vim
+++ b/plugin/tagabana.vim
@@ -15,7 +15,12 @@ let g:loaded_tagabana = 1
 
 " Central tag directory
 if ! exists('g:tagabana_tags_dir')
-	let g:tagabana_tags_dir = $XDG_CACHE_HOME.'/vim/tags/'
+	if empty($XDG_CACHE_HOME)
+		let s:cache_dir = $HOME.'/.cache'
+	else
+		let s:cache_dir = $XDG_CACHE_HOME
+	endif
+	let g:tagabana_tags_dir = s:cache_dir.'/vim/tags/'
 else
 	" Append a forward-slash if missing
 	if g:tagabana_tags_dir !~ '/$'


### PR DESCRIPTION
This plugin looks promising but it took me some time to solve various problems during the initial setup:

- the ctags script expects the cache directory to exist
- in the main vim script, the fallback to `~/.cache` from `$XDG_CACHE_HOME` was not implemented
- there is no mention of the `hooks.ctags.enable` option in the docs and the script crashed if it was not set

I tried to fix these issues in the hope of easing adoption for new users.